### PR TITLE
refactor(docker): handle postgres unavailability

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,28 +1,30 @@
 version: '3.5'
 services:
+  postgres:
+    container_name: django-postgres
+    image: postgres:12.4
+    expose:
+      - 5432
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=blinder
+
   web:
     container_name: django-web
     build: .
-    command: "bash -c 'echo wait postgres && sleep 15s && python manage.py makemigrations && python manage.py migrate && python manage.py runserver 0.0.0.0:8000'"
+    command: "bash -c 'python manage.py makemigrations && python manage.py migrate && python manage.py runserver 0.0.0.0:8000'"
+    restart: on-failure:10
     volumes:
       - ./src:/app
     ports:
       - "8000:8000"
     env_file:
       - ./src/.env
-    depends_on: 
+    depends_on:
       - "postgres"
-  postgres:
-    container_name: django-postgres
-    image: postgres:12.4
-    expose:
-      - 5432
-    volumes: 
-      - db-data:/var/lib/postgresql/data
-    environment: 
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_DB=blinder
 
-volumes: 
+volumes:
   db-data:


### PR DESCRIPTION
Closes #10.

Also, see https://stackoverflow.com/a/52699978. `docker-compose` doesn't wait for the container to be healthy, and there is no way to check for `condition` as of version 3 of docker-compose. This will ensure that if the container is unavailable, that the application will attempt to restart on failure.

